### PR TITLE
Fix for when config isn't provided for plugin.

### DIFF
--- a/hgn.js
+++ b/hgn.js
@@ -16,7 +16,7 @@ define(['hogan', 'text'], function (hogan, text) {
 
 
     function load(name, req, onLoad, config){
-        var hgnConfig = config.hgn;
+        var hgnConfig = config.hgn || {};
         var fileName = name;
         fileName += hgnConfig && hgnConfig.templateExtension != null? hgnConfig.templateExtension : DEFAULT_EXTENSION;
 


### PR DESCRIPTION
When a configuration isn't provided for the plugin - line 25

```
var compilationOptions = hgnConfig.compilationOptions? mixIn({}, hgnConfig.compilationOptions) : {};
```

was throwing an error because hgnConfig was undefined.
- tested with require 2.0.2 
