### PR TITLE
Partial inlining

### DIFF
--- a/hgn.js
+++ b/hgn.js
@@ -18,9 +18,11 @@ define(['hogan', 'text', 'module'], function (hogan, text, module) {
     var _buildTemplate;
 
     function load(name, req, onLoad, config) {
+        var hgnConfig = Object.keys(pluginConfig).length ? pluginConfig : (config.hgn || {});
+
         // load text files with text plugin
-        getTemplateText(name, req, pluginConfig, function(data){
-            var compilationOptions = mixIn({}, pluginConfig.compilationOptions);
+        getTemplateText(name, req, hgnConfig, function(data){
+            var compilationOptions = mixIn({}, hgnConfig.compilationOptions);
 
             if (config.isBuild) {
                 // store compiled function if build


### PR DESCRIPTION
Recursively inlines partials by making calls to the text loader plugin.
It inlines only the partials with the designated path delimiter in the
partial name (by default, `/`).

This allows the use of partials like `{{> path/to/template}}` without
having to manually do it. Configuration can be done through the
RequireJS module configuration instead of using the hgn key on the
RequireJS global configuration object.

```
require.config({
  'path/to/hgn': {
    pathPrefix: 'templates/'
  }
});
```
